### PR TITLE
[BREAKING] Move to ESM-only for the browser, and ESM/CJS for Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Date format is YYYY-MM-DD.
 
+## UNRELEASED
+
+There are no API additions/changes in this release. The focus is on ESM.
+
+### 🚨 BREAKING
+
+- ESM-only for the browser: UMD and CJS browser builds have been removed (see [ESM in browser](./README.md#esm-in-browser) for an example of how to import this directly into the browser as a global).
+- ESM and CJS for Node, with `.cjs` (`require()`) and `.mjs` (`import`) builds.
+- Library now uses/depends (as a peer) on `lodash-es` (ESM) instead of `lodash` (CJS).
+- When importing the library (e.g. `import * as rtv from 'rtvjs'`), it will import from the __slim__ build by default
+    - The assumption is it's being imported for use in an app/library that will provide the necessary externals in its build/package rather than import from the self-contained build and cause duplication of its dependencies (and possibly conflicts at runtime).
+- File structure under the published `./dist` directory has changed: Files are now split between `node` and `browser` directories.
+- See [Installation](./README.md#installation) for information on which files are meant to be used where. Some previous formats are no longer available.
+- The `main` field in `package.json` has been removed in favor of `exports`.
+- Minimum supported version of Node is `v16.12.0` (for ESM support).
+
+### Added
+
+- Minified version of the ESM build for use in browsers.
+
+### Changed
+
+- `@babel/runtime` and `lodash-es` are now `peerDependencies` since they are required for the `slim` builds.
+
 ## 4.1.1
 
 Release date: 2024-02-17

--- a/README.md
+++ b/README.md
@@ -16,77 +16,49 @@ Give it a [test drive with RunKit](https://npm.runkit.com/rtvjs)!
 npm install rtvjs
 ```
 
-The package's `./dist` directory contains 3 types of builds:
+The package's `./dist` directory contains various types of builds:
 
-*   `rtv[.slim].js`: CJS (not minified, for use by bundlers)
-*   `rtv.esm[.slim].js`: ESM (not minified, for use by bundlers)
-*   `rtv.umd[.slim][.dev].js`: UMD (minified, for use in browsers, self-contained)
+*   `./node/rtv[.dev].cjs`: CJS (not minified, primarily for use in Node)
+*   `./node/rtv[.slim][.dev].mjs`: ESM (not minified, primarily for use in Node)
+*   `./browser/rtv.esm[.slim][.dev].js`: ESM (not minified, for use by bundlers or for debugging; non-slim/self-contained versions are also good for browser debugging)
+*   `./browser/rtv.esm.min.js`: ESM (minified, primarily for use directly in the browser)
 
-The CJS and ESM builds require defining the `process.env.NODE_ENV` to either `"development"` or `"production"`. The UMD 'dev' build is the equivalent of defining `process.env.NODE_ENV = "development"`.
+## Dev
+
+The `.dev` CJS and ESM builds include dev-only features such as deprecation warnings and more helpful console logs.
 
 ## Slim
 
 These builds are smaller in size to optimize on download time and bundling efficiency.
 
-The `.slim` CJS and ESM builds depend on [@babel/runtime](https://babeljs.io/docs/en/babel-runtime) and [lodash](https://lodash.com/) external dependencies. You will need to install those packages in addition to `rtvjs`.
-
-> See the [package.json](./package.json)'s `devDependencies` to know what versions of those dependencies are required when using slim builds.
-
-The `.slim` UMD builds only depend on [lodash](https://lodash.com/) being defined as the `_` global:
-
-```html
-<script src="https://unpkg.com/lodash"></script>
-<script src="./dist/rtv.umd.slim.js"></script>
-```
+The `.slim` CJS and ESM builds depend on [@babel/runtime](https://babeljs.io/docs/en/babel-runtime) and [lodash-es](https://lodash-es.com/) external dependencies, both of which should automatically get installed when you install `rtvjs`.
 
 ## CJS
 
-The CJS build can be used like this, typically in Node.js, or with a bundler like Webpack or Rollup:
+The CJS build can be used like this in a Node.js script:
 
 ```javascript
 const rtv = require('rtvjs');
 ```
 
-Be sure to set `process.env.NODE_ENV = "development"` if you want to enable the dev code it contains (e.g. deprecation warnings). To exclude the dev code, set `process.env.NODE_ENV = "production"` (or any value other than `"development"`).
-
-Use the [Webpack Define Plugin](https://webpack.js.org/plugins/define-plugin/) or the [Rollup Replace Plugin](https://www.npmjs.com/package/@rollup/plugin-replace), for example, to configure this in your build.
-
 ## ESM
 
-The ESM build can be used like this (note a default export is not provided):
+The ESM build can be used like this either in Node.js, a bundler, or the browser (note a default export is not provided):
 
 ```javascript
 import * as rtv from 'rtvjs'; // import all into an `rtv` namespace
 import { verify, STRING, ... } from 'rtvjs'; // selective imports only
 ```
 
-> The CJS considerations above also apply to this build (externals and environment).
+### ESM in browser
 
-## UMD
-
-The UMD build comes in two files:
-
--   `./dist/rtv.umd[.slim].dev.js`: For development. Non-minified, and includes dev code such as deprecation warnings (if any).
--   `./dist/rtv.umd[.slim].js`: For production. Minified, and excludes any dev code.
--   `.slim` depends on `_` as the `lodash` global in both cases.
-
-Use it like this:
-
-```javascript
-// as a CommonJS module (e.g. Node.js)
-const rtvjs = require('./dist/rtv.umd.js'); // OR: `./dist/rtv.umd.dev.js`
-rtvjs.verify(...);
-
-// as an AMD module (e.g. RequireJS)
-define(['rtvjs'], function(rtvjs) {
-  rtvjs.verify(...);
-});
-```
+While a UMD build isn't provided, it's still possible to load the library as a global directly in the browser as follows:
 
 ```html
-<!-- as a global, when loaded via a <script> tag in HTML -->
-<script src="./dist/rtv.umd.js"></script>
-<script>rtvjs.verify(...)</script>
+<script type="module">
+  import * as rtv from 'https://unpkg.com/rtvjs@5/dist/browser/rtv.esm.min.js';
+  window.rtv = rtv;
+</script>
 ```
 
 > The __non-slim__ builds are self-contained and optimized for browsers.

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -32,7 +32,7 @@ const mkConfig = function () {
       //  to be transpiled via 'babel-jest' configured in the 'transform' option
       // @see https://github.com/facebook/jest/issues/9292#issuecomment-569673251
       'node_modules/(?!(' +
-        // 'first-lib' +
+        'lodash-es' +
         // '|other-lib' +
         ')/)',
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,14 +33,18 @@
         "jest-transform-stub": "^2.0.0",
         "jsdoc-to-markdown": "^8.0.3",
         "live-server": "^1.2.2",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "prettier": "^3.3.3",
         "rollup": "^4.19.1",
         "rollup-plugin-terser": "^7.0.2"
       },
       "engines": {
-        "node": ">=14.18.0",
+        "node": ">=16.12.0",
         "npm": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.24.5",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4572,12 +4576,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -6581,10 +6586,11 @@
       "optional": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -7430,6 +7436,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -10067,6 +10074,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -12663,6 +12677,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -13261,10 +13276,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16571,12 +16587,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -18081,9 +18097,9 @@
       "optional": true
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -20709,6 +20725,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -23208,9 +23230,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -3,11 +3,17 @@
   "version": "4.1.1",
   "description": "Runtime Verification Library for browsers and Node.js.",
   "engines": {
-    "node": ">=14.18.0",
+    "node": ">=16.12.0",
     "npm": ">=10.0.0"
   },
-  "main": "dist/rtv.js",
-  "module": "dist/rtv.esm.js",
+  "module": "dist/browser/rtv.esm.slim.js",
+  "exports": {
+    ".": {
+      "node": "./dist/node/rtv.cjs",
+      "import": "./dist/browser/rtv.esm.slim.js",
+      "default": "./dist/browser/rtv.esm.js"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "api": "jsdoc2md -f \"src/**/*.js\" -f \"src/**/*.jsdoc\" --heading-depth 1 > API.md",
@@ -29,9 +35,10 @@
     "lint": "eslint ./*.js \"src/**/*.{js,jsdoc}\" \"test/**/*.js\" \"tools/**/*.js\"",
     "html": "npm run build:lib && npm run html:live",
     "html:live": "live-server --no-browser --mount=\"/dist:./dist\" ./tools",
-    "node": "echo \"\n!!! REMEMBER TO REBUILD IF NECESSARY !!!\n\n\" && node -r ./tools/node.js --inspect",
+    "node": "echo \"\n⚠️ REMEMBER TO REBUILD IF NECESSARY ⚠️\n\n\" && node --import=./tools/node.mjs --inspect",
+    "node:cjs": "echo \"\n⚠️ REMEMBER TO REBUILD IF NECESSARY ⚠️\n\n\" && node -r ./tools/node.cjs --inspect",
     "node:build": "npm run build:lib && npm run node",
-    "node:internals": "npm run build:internals && node -r ./dist_tools/internals.js --inspect",
+    "node:internals": "npm run build:internals && node --import=./dist_tools/internals.mjs --inspect",
     "precommit:api": "git add API.md",
     "precommit:msg": "echo 'Running pre-commit checks...'",
     "prepare": "husky",
@@ -81,6 +88,10 @@
     "README.md",
     "dist/"
   ],
+  "peerDependencies": {
+    "@babel/runtime": "^7.24.5",
+    "lodash-es": "^4.17.21"
+  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/eslint-parser": "^7.25.1",
@@ -106,7 +117,7 @@
     "jest-transform-stub": "^2.0.0",
     "jsdoc-to-markdown": "^8.0.3",
     "live-server": "^1.2.2",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "prettier": "^3.3.3",
     "rollup": "^4.19.1",
     "rollup-plugin-terser": "^7.0.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,12 +3,96 @@
 const builds = require('./tools/build/rollup-builds');
 
 module.exports = [
-  builds.getCjsConfig(), // Dev and Prod combined
-  builds.getCjsConfig({ isSlim: true }), // Dev and Prod combined, externals
-  builds.getEsmConfig(), // Dev and Prod combined
-  builds.getEsmConfig({ isSlim: true }), // Dev and Prod combined, externals
-  builds.getUmdConfig({ isDev: true }), // Dev (not minified)
-  builds.getUmdConfig({ isDev: true, isSlim: true }), // Dev (not minified), externals
-  builds.getUmdConfig(), // Prod + minified
-  builds.getUmdConfig({ isSlim: true }), // Prod + minified, externals
+  //// CJS NODE -- NO MIN builds INTENTIONALLY (Node doesn't need this optimization)
+  ////  and no 'slim' builds because that results in external imports to lodash-es
+  ////  which is ESM-only and incompatible with CJS
+
+  // Prod, self-contained
+  builds.getCjsConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: false,
+    target: 'node',
+  }),
+  // Dev, self-contained
+  builds.getCjsConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: true,
+    target: 'node',
+  }),
+
+  //// ESM NODE -- NO MIN builds INTENTIONALLY (Node doesn't need this optimization)
+
+  // Prod, self-contained
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: false,
+    target: 'node',
+  }),
+  // Prod, externals
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: true,
+    isDev: false,
+    target: 'node',
+  }),
+  // Dev, self-contained
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: true,
+    target: 'node',
+  }),
+  // Dev, externals
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: true,
+    isDev: true,
+    target: 'node',
+  }),
+
+  //// ESM BROWSER PROD -- Only Prod builds should be minified
+
+  // Prod, self-contained -- bundler
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: false,
+    target: 'browser',
+  }),
+  // Prod, externals -- bundler
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: true,
+    isDev: false,
+    target: 'browser',
+  }),
+  // Prod, self-contained, minified -- in-browser
+  builds.getEsmConfig({
+    isMin: true,
+    isSlim: false,
+    isDev: false,
+    target: 'browser',
+  }),
+  // NOTE: Prod with externals and minified (i.e. slim/minified) for use in-browser doesn't
+  //  make sense because it'll have export imports that won't be resolvable
+
+  //// ESM BROWSER DEV -- No minification
+
+  // Dev, self-contained -- bundler or in-browser
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: false,
+    isDev: true,
+    target: 'browser',
+  }),
+  // Dev, externals -- bundler or in-browser
+  builds.getEsmConfig({
+    isMin: false,
+    isSlim: true,
+    isDev: true,
+    target: 'browser',
+  }),
 ];

--- a/src/lib/validation/isAnyObject.js
+++ b/src/lib/validation/isAnyObject.js
@@ -1,6 +1,6 @@
 ////// isAnyObject validation
 
-import { default as _isObject } from 'lodash/isObject';
+import { default as _isObject } from 'lodash-es/isObject.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isArray.js
+++ b/src/lib/validation/isArray.js
@@ -1,6 +1,6 @@
 ////// isArray validation
 
-import { default as _isArray } from 'lodash/isArray';
+import { default as _isArray } from 'lodash-es/isArray.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isDate.js
+++ b/src/lib/validation/isDate.js
@@ -1,6 +1,6 @@
 ////// isDate validation
 
-import { default as _isDate } from 'lodash/isDate';
+import { default as _isDate } from 'lodash-es/isDate.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isError.js
+++ b/src/lib/validation/isError.js
@@ -1,6 +1,6 @@
 ////// isError validation
 
-import { default as _isError } from 'lodash/isError';
+import { default as _isError } from 'lodash-es/isError.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isFalsy.js
+++ b/src/lib/validation/isFalsy.js
@@ -1,6 +1,6 @@
 ////// isFalsy validation module
 
-import { default as _isNaN } from 'lodash/isNaN';
+import { default as _isNaN } from 'lodash-es/isNaN.js';
 
 /**
  * Validation Module: isFalsy

--- a/src/lib/validation/isFinite.js
+++ b/src/lib/validation/isFinite.js
@@ -1,6 +1,6 @@
 ////// isFinite validation
 
-import { default as _isFinite } from 'lodash/isFinite';
+import { default as _isFinite } from 'lodash-es/isFinite.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isFunction.js
+++ b/src/lib/validation/isFunction.js
@@ -1,6 +1,6 @@
 ////// isFunction validation
 
-import { default as _isFunction } from 'lodash/isFunction';
+import { default as _isFunction } from 'lodash-es/isFunction.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isInt.js
+++ b/src/lib/validation/isInt.js
@@ -1,6 +1,6 @@
 ////// isInt validation
 
-import { default as _isInteger } from 'lodash/isInteger';
+import { default as _isInteger } from 'lodash-es/isInteger.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isMap.js
+++ b/src/lib/validation/isMap.js
@@ -1,6 +1,6 @@
 ////// isMap validation
 
-import { default as _isMap } from 'lodash/isMap';
+import { default as _isMap } from 'lodash-es/isMap.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isNumber.js
+++ b/src/lib/validation/isNumber.js
@@ -1,6 +1,6 @@
 ////// isNumber validation
 
-import { default as _isNaN } from 'lodash/isNaN';
+import { default as _isNaN } from 'lodash-es/isNaN.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isObject.js
+++ b/src/lib/validation/isObject.js
@@ -1,6 +1,6 @@
 ////// isObject validation
 
-import { default as _isObjectLike } from 'lodash/isObjectLike';
+import { default as _isObjectLike } from 'lodash-es/isObjectLike.js';
 
 import { check as isArray } from './isArray';
 import { check as isMap } from './isMap';

--- a/src/lib/validation/isPlainObject.js
+++ b/src/lib/validation/isPlainObject.js
@@ -1,6 +1,6 @@
 ////// isPlainObject validation
 
-import { default as _isPlainObject } from 'lodash/isPlainObject';
+import { default as _isPlainObject } from 'lodash-es/isPlainObject.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isRegExp.js
+++ b/src/lib/validation/isRegExp.js
@@ -1,6 +1,6 @@
 ////// isRegExp validation
 
-import { default as _isRegExp } from 'lodash/isRegExp';
+import { default as _isRegExp } from 'lodash-es/isRegExp.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isSafeInt.js
+++ b/src/lib/validation/isSafeInt.js
@@ -1,6 +1,6 @@
 ////// isSafeInt validation
 
-import { default as _isSafeInteger } from 'lodash/isSafeInteger';
+import { default as _isSafeInteger } from 'lodash-es/isSafeInteger.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isSet.js
+++ b/src/lib/validation/isSet.js
@@ -1,6 +1,6 @@
 ////// isSet validation
 
-import { default as _isSet } from 'lodash/isSet';
+import { default as _isSet } from 'lodash-es/isSet.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isSymbol.js
+++ b/src/lib/validation/isSymbol.js
@@ -1,6 +1,6 @@
 ////// isSymbol validation
 
-import { default as _isSymbol } from 'lodash/isSymbol';
+import { default as _isSymbol } from 'lodash-es/isSymbol.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isTypeset.js
+++ b/src/lib/validation/isTypeset.js
@@ -1,6 +1,6 @@
 ////// isTypeset validation module
 
-import { default as _forEach } from 'lodash/forEach';
+import { default as _forEach } from 'lodash-es/forEach.js';
 
 import { check as isArray } from './isArray';
 import { check as isShape } from './isShape';

--- a/src/lib/validation/isWeakMap.js
+++ b/src/lib/validation/isWeakMap.js
@@ -1,6 +1,6 @@
 ////// isWeakMap validation
 
-import { default as _isWeakMap } from 'lodash/isWeakMap';
+import { default as _isWeakMap } from 'lodash-es/isWeakMap.js';
 
 import { types } from '../types';
 

--- a/src/lib/validation/isWeakSet.js
+++ b/src/lib/validation/isWeakSet.js
@@ -1,6 +1,6 @@
 ////// isWeakSet validation
 
-import { default as _isWeakSet } from 'lodash/isWeakSet';
+import { default as _isWeakSet } from 'lodash-es/isWeakSet.js';
 
 import { types } from '../types';
 

--- a/src/lib/validator/valAnyObject.js
+++ b/src/lib/validator/valAnyObject.js
@@ -1,7 +1,7 @@
 ////// valAnyObject validator
 
-import _forEach from 'lodash/forEach';
-import _difference from 'lodash/difference';
+import _forEach from 'lodash-es/forEach.js';
+import _difference from 'lodash-es/difference.js';
 
 import { type, check as isAnyObject } from '../validation/isAnyObject';
 

--- a/src/lib/validator/valArray.js
+++ b/src/lib/validator/valArray.js
@@ -1,6 +1,6 @@
 ////// valArray validator
 
-import { default as _forEach } from 'lodash/forEach';
+import { default as _forEach } from 'lodash-es/forEach.js';
 
 import { type, check as isArray } from '../validation/isArray';
 

--- a/src/lib/validator/valClassObject.js
+++ b/src/lib/validator/valClassObject.js
@@ -1,7 +1,7 @@
 ////// valClassObject validator
 
-import _forEach from 'lodash/forEach';
-import _difference from 'lodash/difference';
+import _forEach from 'lodash-es/forEach.js';
+import _difference from 'lodash-es/difference.js';
 
 import { type, check as isClassObject } from '../validation/isClassObject';
 

--- a/src/lib/validator/valHashMap.js
+++ b/src/lib/validator/valHashMap.js
@@ -1,6 +1,6 @@
 ////// valHashMap validator
 
-import _forEach from 'lodash/forEach';
+import _forEach from 'lodash-es/forEach.js';
 
 import { type, check as isHashMap } from '../validation/isHashMap';
 

--- a/src/lib/validator/valNumber.js
+++ b/src/lib/validator/valNumber.js
@@ -1,6 +1,6 @@
 ////// valNumber validator
 
-import { default as _isNaN } from 'lodash/isNaN';
+import { default as _isNaN } from 'lodash-es/isNaN.js';
 
 import { type, check as isNumber } from '../validation/isNumber';
 

--- a/src/lib/validator/valObject.js
+++ b/src/lib/validator/valObject.js
@@ -1,7 +1,7 @@
 ////// valObject validator
 
-import _forEach from 'lodash/forEach';
-import _difference from 'lodash/difference';
+import _forEach from 'lodash-es/forEach.js';
+import _difference from 'lodash-es/difference.js';
 
 import { type, check as isObject } from '../validation/isObject';
 

--- a/src/lib/validator/valPlainObject.js
+++ b/src/lib/validator/valPlainObject.js
@@ -1,7 +1,7 @@
 ////// valPlainObject validator
 
-import _forEach from 'lodash/forEach';
-import _difference from 'lodash/difference';
+import _forEach from 'lodash-es/forEach.js';
+import _difference from 'lodash-es/difference.js';
 
 import { type, check as isPlainObject } from '../validation/isPlainObject';
 

--- a/test/lib/Enumeration.test.js
+++ b/test/lib/Enumeration.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import { Enumeration } from '../../src/lib/Enumeration';
 

--- a/test/lib/qualifiers.test.js
+++ b/test/lib/qualifiers.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import * as pqs from '../../src/lib/onlyQualifiers';
 import * as mod from '../../src/lib/qualifiers';

--- a/test/lib/types.test.js
+++ b/test/lib/types.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import * as pts from '../../src/lib/onlyTypes';
 import * as mod from '../../src/lib/types';

--- a/test/lib/validation/isAny.test.js
+++ b/test/lib/validation/isAny.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isAnyObject.test.js
+++ b/test/lib/validation/isAnyObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isClassObject.test.js
+++ b/test/lib/validation/isClassObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isFinite.test.js
+++ b/test/lib/validation/isFinite.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isFloat.test.js
+++ b/test/lib/validation/isFloat.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isHashMap.test.js
+++ b/test/lib/validation/isHashMap.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isInt.test.js
+++ b/test/lib/validation/isInt.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isNumber.test.js
+++ b/test/lib/validation/isNumber.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isObject.test.js
+++ b/test/lib/validation/isObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isPlainObject.test.js
+++ b/test/lib/validation/isPlainObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isSafeInt.test.js
+++ b/test/lib/validation/isSafeInt.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isShape.test.js
+++ b/test/lib/validation/isShape.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validation/isTypeArgs.test.js
+++ b/test/lib/validation/isTypeArgs.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validationTestUtil.js
+++ b/test/lib/validationTestUtil.js
@@ -2,7 +2,7 @@
 // Utility for testing validation and validator modules
 //
 
-import _ from 'lodash';
+import _ from 'lodash-es';
 import { types } from '../../src/lib/types';
 import { qualifiers, DEFAULT_QUALIFIER } from '../../src/lib/qualifiers';
 import * as util from '../../src/lib/util';

--- a/test/lib/validator/valAny.test.js
+++ b/test/lib/validator/valAny.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valAnyObject.test.js
+++ b/test/lib/validator/valAnyObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valArray.test.js
+++ b/test/lib/validator/valArray.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valClassObject.test.js
+++ b/test/lib/validator/valClassObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valFinite.test.js
+++ b/test/lib/validator/valFinite.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valFloat.test.js
+++ b/test/lib/validator/valFloat.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valHashMap.test.js
+++ b/test/lib/validator/valHashMap.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valInt.test.js
+++ b/test/lib/validator/valInt.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valNumber.test.js
+++ b/test/lib/validator/valNumber.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valObject.test.js
+++ b/test/lib/validator/valObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valPlainObject.test.js
+++ b/test/lib/validator/valPlainObject.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valSafeInt.test.js
+++ b/test/lib/validator/valSafeInt.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/lib/validator/valString.test.js
+++ b/test/lib/validator/valString.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import '../../../src/rtv'; // make sure all validators we might use in typesets get configured
 import * as vtu from '../validationTestUtil';

--- a/test/rtv.test.js
+++ b/test/rtv.test.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash-es';
 
 import * as rtv from '../src/rtv';
 import { types } from '../src/lib/types';

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -28,15 +28,20 @@ const addProcessHandlers = function (cmd, onClose = closeHandler) {
   cmd.on('close', onClose);
 };
 
-if (!pkg.main) {
+if (
+  !pkg.exports?.['.'] ||
+  !pkg.exports?.['.']?.node ||
+  !pkg.exports?.['.']?.import ||
+  !pkg.exports?.['.']?.default
+) {
   throw new Error(
-    `'main' property in ${pkgFilePath} must be set to CJS bundle`
+    `\`exports['.'].node/import/default\` properties in ${pkgFilePath} must be set`
   );
 }
 
 if (!pkg.module) {
   throw new Error(
-    `'module' property in ${pkgFilePath} must be set to ESM bundle`
+    `\`module\` property in ${pkgFilePath} must be set to ESM bundle`
   );
 }
 

--- a/tools/build/rollup-utils.js
+++ b/tools/build/rollup-utils.js
@@ -6,14 +6,20 @@ const RU_FORMAT_CJS = 'cjs';
 // {string} Rollup ESM output format
 const RU_FORMAT_ESM = 'es';
 
-// {string} Rollup UMD output format
-const RU_FORMAT_UMD = 'umd';
-
-// {string} Sub-extension used in development (i.e. non-minified) builds
+// {string} Sub-extension used in development (i.e. non-production) builds
 const OUTPUT_DEV = 'dev';
+
+// {string} Sub-extension used in minified builds
+const OUTPUT_MIN = 'min';
 
 // {string} Sub-extension used for slim (i.e. non-bundled) builds
 const OUTPUT_SLIM = 'slim';
+
+// {string} Target run platform for a browser
+const TARGET_BROWSER = 'browser';
+
+// {string} Target run platform for Node
+const TARGET_NODE = 'node';
 
 // {string} input directory relative path, no trailing slash
 const DIR_SRC = 'src';
@@ -24,9 +30,11 @@ const DIR_DIST = 'dist';
 module.exports = {
   RU_FORMAT_CJS,
   RU_FORMAT_ESM,
-  RU_FORMAT_UMD,
   OUTPUT_DEV,
+  OUTPUT_MIN,
   OUTPUT_SLIM,
+  TARGET_BROWSER,
+  TARGET_NODE,
   DIR_SRC,
   DIR_DIST,
 };

--- a/tools/index.html
+++ b/tools/index.html
@@ -4,13 +4,22 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=768, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>RTV.js - UMD</title>
-  <script src="https://unpkg.com/lodash"></script>
-  <script src="./dist/rtv.umd.slim.dev.js"></script>
+  <title>RTV.js - ESM</title>
+  <script type="module">
+    import * as _ from 'https://unpkg.com/lodash-es';
+    window._ = _;
+  </script>
+  <script type="module">
+    import * as rtv from './dist/browser/rtv.esm.dev.js';
+    window.rtv = rtv;
+  </script>
 </head>
 <body>
   <p style="text-align: center; margin-top: 20px">
-    RTV.js is loaded into <code><b>window.rtvjs</b></code> from the UMD build.
+    RTV.js is loaded into <code><b>window.rtv</b></code> from the ESM/dev build.
+  </p>
+  <p style="text-align: center; margin-top: 20px">
+    Lodash-es is loaded into <code><b>window._</b></code> from <code>unpkg.com</code>.
   </p>
 </body>
 </html>

--- a/tools/node.cjs
+++ b/tools/node.cjs
@@ -1,0 +1,10 @@
+////// Manual CJS Node.js Testing
+
+// eslint-disable-next-line node/no-missing-require -- only exists if `npm run build` has run
+global.rtv = require('../dist/node/rtv.cjs');
+
+// NOTE: not possible to load lodash-es because it's ESM only
+
+global.ostr = function (v) {
+  return Object.prototype.toString.call(v);
+};

--- a/tools/node.mjs
+++ b/tools/node.mjs
@@ -1,11 +1,14 @@
-////// Manual Node.js Testing
+////// Manual ESM Node.js Testing
 
 // NOTE: this will load because Node will naturally resolve the external references
 //  to @babel/runtime and lodash in ../node_modules
 // eslint-disable-next-line node/no-missing-require -- only exists if `npm run build` has run
-global.rtv = require('../dist/rtv.slim.js');
+import * as rtv from '../dist/node/rtv.slim.mjs';
+global.rtv = rtv;
 
-global.ld = require('lodash');
+import * as _ from 'lodash-es';
+global.ld = _;
+
 global.ostr = function (v) {
   return Object.prototype.toString.call(v);
 };

--- a/tools/rollup.internals.js
+++ b/tools/rollup.internals.js
@@ -3,6 +3,7 @@
 const jsonPlugin = require('@rollup/plugin-json');
 const { nodeResolve: resolvePlugin } = require('@rollup/plugin-node-resolve');
 const cjsPlugin = require('@rollup/plugin-commonjs');
+const replacePlugin = require('@rollup/plugin-replace');
 
 const LIB_NAME = 'internals';
 
@@ -11,12 +12,16 @@ const config = {
   output: [
     // CJS Module build
     {
-      file: `dist_tools/${LIB_NAME}.js`,
-      format: 'cjs',
-      sourcemap: true,
+      file: `dist_tools/${LIB_NAME}.mjs`,
+      format: 'esm',
+      sourcemap: false,
     },
   ],
   plugins: [
+    replacePlugin({
+      values: {}, // none for now
+      preventAssignment: true,
+    }),
     jsonPlugin(),
     resolvePlugin(),
     cjsPlugin({


### PR DESCRIPTION
There are no API additions/changes in this commit. The focus is on ESM.

### 🚨 BREAKING

- ESM-only for the browser: UMD and CJS browser builds have been removed (see [ESM in browser](./README.md#esm-in-browser) for an example of how to import this directly into the browser as a global).
- ESM and CJS for Node, with `.cjs` (`require()`) and `.mjs` (`import`) builds.
- Library now uses/depends (as a peer) on `lodash-es` (ESM) instead of `lodash` (CJS).
- When importing the library (e.g. `import * as rtv from 'rtvjs'`), it will import from the __slim__ build by default
    - The assumption is it's being imported for use in an app/library that will provide the necessary externals in its build/package rather than import from the self-contained build and cause duplication of its dependencies (and possibly conflicts at runtime).
- File structure under the published `./dist` directory has changed: Files are now split between `node` and `browser` directories.
- See [Installation](./README.md#installation) for information on which files are meant to be used where. Some previous formats are no longer available.
- The `main` field in `package.json` has been removed in favor of `exports`.
- Minimum supported version of Node is `v16.12.0` (for ESM support).

### Added

- Minified version of the ESM build for use in browsers.

### Changed

- `@babel/runtime` and `lodash-es` are now `peerDependencies` since they are required for the `slim` builds.